### PR TITLE
Fix maximum zoom being one level too low

### DIFF
--- a/tool_src/TileCutter/MainForm.cs
+++ b/tool_src/TileCutter/MainForm.cs
@@ -90,7 +90,7 @@ namespace TileCutter
         private int CalculateMaxZoom(int size, int tileSize)
         {
             int zoom = 0;
-            while ((size /= 2) > tileSize) zoom++;
+            while ((size /= 2) >= tileSize) zoom++;
             return zoom;
         }
 


### PR DESCRIPTION
The original issue was that with a 8192x8192px photo, TileCutter was only allowing a zoom level up to 4. However, 5 would be a more reasonable zoom level and also what other tile cutting tools allowed.

The problem was narrowed down to a relational operator that was returning false on the 5th zoom level even though it was valid. 

The input photo's size is divided by 2 for every comparison and checked against the tile size. If the result is greater, then the comparison returns true. However if the result is the same, which it is when you calculate `8192/2^5`, the comparison returns false because the resulting size (256) is the same as the tile size (256).

This fix simply makes it so the comparison returns true if the result is greater than or equal to the tile size.